### PR TITLE
Fixed profile information for new Facebook API

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ public function initialize(){
     $this->loadComponent('AkkaFacebook.Graph', [
 	    'app_id' => 'your-fb-app-id',
 	    'app_secret' => 'your-fb-app-secret',
-	    'app_scope' => 'email', // https://developers.facebook.com/docs/facebook-login/permissions/v2.3
+	    'app_scope' => 'email,public_profile', // https://developers.facebook.com/docs/facebook-login/permissions/v2.4
 	    'redirect_url' => Router::url(['controller' => 'Users', 'action' => 'login'], TRUE), // This should be enabled by default
 	    'post_login_redirect' => '' //ie. Router::url(['controller' => 'Users', 'action' => 'account'], TRUE)
 	    // 'user_columns' => ['first_name' => 'fname', 'last_name' => 'lname', 'username' => 'uname', 'password' => 'pass'] //not required

--- a/src/Controller/Component/GraphComponent.php
+++ b/src/Controller/Component/GraphComponent.php
@@ -239,7 +239,7 @@ class GraphComponent extends Component {
 	if ($this->FacebookSession)
 	{
 	    try {
-		$this->FacebookRequest = new FacebookRequest($this->FacebookSession, 'GET', '/me');
+		$this->FacebookRequest = new FacebookRequest($this->FacebookSession, 'GET', '/me?fields=name,email,first_name,last_name);
 		$this->FacebookResponse = $this->FacebookRequest->execute();
 		$this->FacebookGraphObject = $this->FacebookResponse->getGraphObject();
 		$this->FacebookGraphUser = $this->FacebookGraphObject->cast(GraphUser::className());


### PR DESCRIPTION
Fields are not sent by default in API V2.4 which is what the Facebook PHP API appears to be using. I updated the graph and the readme to reflect these changes for the login functionality.

For more info about why this is needed see: http://stackoverflow.com/questions/31692355/facebook-only-returning-name-and-id-of-user
